### PR TITLE
ADD: complete firmware to getFirmware function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 node_js:
   - "4.8.4"
-  - "6.11.1"
-  - "7.10.1"
-  - "8.1.4"
+  - "6"
+  - "7"
+  - "8"
+  - "9"
 install:
   - npm install --all
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements 
 
 * Add raw of version to `getFirmware` 
+* Bump mathjs to 4.0.0 to resolve insecurity
 
 # v0.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.3.3
+
+### Enhancements 
+
+* Add raw of version to `getFirmware` 
+
 # v0.3.1
 
 ### Enhancements 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "buffer-equal": "^1.0.0",
     "clone": "^2.0.0",
     "gaussian": "^1.0.0",
-    "mathjs": "^3.3.0",
+    "mathjs": "^4.0.0",
     "performance-now": "^2.1.0",
     "streamsearch": "^0.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci-utilities",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "description": "The official utility package of Node.js SDK for the OpenBCI Biosensor Boards.",
   "main": "dist/openbci-utilities.js",
   "module": "src/index.js",

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -2164,7 +2164,8 @@ function getFirmware (dataBuffer) {
     return {
       major: Number(elems[0][1]),
       minor: Number(elems[1]),
-      patch: Number(elems[2])
+      patch: Number(elems[2]),
+      raw: ret[0]
     };
   } else return ret;
 }

--- a/test/openBCIUtilities-test.js
+++ b/test/openBCIUtilities-test.js
@@ -2125,7 +2125,8 @@ $$$`);
       expect(openBCIUtilities.getFirmware(buf)).to.deep.equal({
         major: 2,
         minor: 0,
-        patch: 1
+        patch: 1,
+        raw: 'v2.0.1'
       });
     });
     it('should find a v3', function () {
@@ -2139,7 +2140,23 @@ $$$`);
       expect(openBCIUtilities.getFirmware(buf)).to.deep.equal({
         major: 3,
         minor: 0,
-        patch: 1
+        patch: 1,
+        raw: 'v3.0.1'
+      });
+    });
+    it('should find a v3 and remove rc', function () {
+      let buf = new Buffer(`OpenBCI V3 Simulator
+On Board ADS1299 Device ID: 0x12345
+On Daisy ADS1299 Device ID: 0xFFFFF
+LIS3DH Device ID: 0x38422
+Firmware: v3.0.1-rc1
+$$$`);
+
+      expect(openBCIUtilities.getFirmware(buf)).to.deep.equal({
+        major: 3,
+        minor: 0,
+        patch: 1,
+        raw: 'v3.0.1'
       });
     });
   });


### PR DESCRIPTION
# v0.3.3

### Enhancements 

* Add raw of version to `getFirmware` 
* Bump mathjs to 4.0.0 to resolve insecurity