### PR TITLE
v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.3.5
+
+### Bug Fixes 
+
+* Fix bug where `getFirmware` failed for patch or minor versions over 9 (aka double digits)
+
 # v0.3.4
 
 ### Bug Fixes 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci-utilities",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "The official utility package of Node.js SDK for the OpenBCI Biosensor Boards.",
   "main": "dist/openbci-utilities.js",
   "module": "src/index.js",

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -2160,7 +2160,7 @@ function doesBufferHaveEOT (dataBuffer) {
  * @return {*}
  */
 function getFirmware (dataBuffer) {
-  const regexPattern = /v\d.\d.\d/;
+  const regexPattern = /v\d.\d*.\d*/;
   const ret = dataBuffer.toString().match(regexPattern);
   if (ret) {
     const elems = ret[0].split('.');

--- a/test/openBCIUtilities-test.js
+++ b/test/openBCIUtilities-test.js
@@ -2159,6 +2159,21 @@ $$$`);
         raw: 'v3.0.1'
       });
     });
+    it('should find a v3 and remove rc', function () {
+      let buf = new Buffer(`OpenBCI V3 Simulator
+On Board ADS1299 Device ID: 0x12345
+On Daisy ADS1299 Device ID: 0xFFFFF
+LIS3DH Device ID: 0x38422
+Firmware: v3.0.11
+$$$`);
+
+      expect(openBCIUtilities.getFirmware(buf)).to.deep.equal({
+        major: 3,
+        minor: 0,
+        patch: 11,
+        raw: 'v3.0.11'
+      });
+    });
   });
   describe('#isFailureInBuffer', function () {
     it('should not crash on small buff', function () {


### PR DESCRIPTION
# v0.3.5

### Bug Fixes 

* Fix bug where `getFirmware` failed for patch or minor versions over 9 (aka double digits)